### PR TITLE
Delay calibration  + unified flagging

### DIFF
--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -71,29 +71,19 @@ if inputs['hanning'] == 1:
 if inputs['rfigui'] == 1:
     em.run_rfigui(vis)
 
-### Flagging and parallelisation ###
-### Check AOflagger version. Decide if old or new procedure is needed. ###
-### if v2.7< do ms2mms fields
-if em.check_aoflagger_version(): #Use J. Moldon's default flagger for mms architecture when -field parameter doesnt exist
-    if inputs['ms2mms'] == 1:
+### Convert MS to MMS ###
+if inputs['ms2mms'] == 1:
+    if em.check_aoflagger_version():
         em.ms2mms_fields(msfile=vis)
-        if os.path.isdir('./'+inputs['inbase']+'.mms') == True:
-            vis = inputs['inbase']+'.mms'
-    if inputs['autoflag'] == 1:
-        if os.path.isdir('./'+inputs['inbase']+'.mms') == True:
-            vis = inputs['inbase']+'.mms'
-        em.run_aoflagger_fields(vis=vis,fields='all', pipeline_path = pipeline_path)
-### if v2.9+ use -field parameter and can generate source specific rfi strategies
-else: ##run aoflagger on .ms file first so that gui works properly if aoflagger >2.9
-	if inputs['autoflag'] == 1:
-		em.run_aoflagger(vis=vis,mode='default')
-	if inputs['ms2mms'] == 1:
-		em.ms2mms(vis=vis,mode='parallel')
+    else:
+        em.ms2mms(vis=vis,mode='parallel')
 
 ## check for parallelisation
 if os.path.isdir('./'+inputs['inbase']+'.mms') == True:
     vis = inputs['inbase']+'.mms'
 
+if inputs['autoflag'] == 1:
+    em.run_aoflagger_fields(vis=vis,fields='all', pipeline_path = pipeline_path)
 
 ### Produce some initial plots ###
 if inputs['do_prediag'] == 1:

--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -33,7 +33,14 @@ logger.info('Running pipeline from: {}'.format(pipeline_path))
 inputs = em.check_in(pipeline_path)
 data_dir = em.backslash_check(inputs['data_dir'])
 plots_dir = em.backslash_check(inputs['plots_dir'])
+calib_dir = em.backslash_check(inputs['calib_dir'])
 logger.info('Inputs used: {}'.format(inputs))
+
+refant = inputs['refant']
+
+## Create directory structure ##
+em.makedir(plots_dir)
+em.makedir(calib_dir)
 
 if inputs['quit'] == 1: #Check from GUI if quit is needed
     logger.debug('Pipeline exit')

--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -90,6 +90,14 @@ if inputs['do_prediag'] == 1:
 	em.do_prediagnostics(vis,plots_dir)
 
 
+### Delay calibration ###
+if inputs['do_delay'] == 1:
+    caltable_name = inputs['inbase']+'_delay.K'
+    em.solve_delays(vis,caltable_name=caltable_name,calsources='',solint='600s',refant=refant,combine='spw',spw='',caldir=calib_dir,plotdir=plots_dir)
+
+
+
+
 logger.info('Pipeline finished')
 logger.info('#################')
 

--- a/functions/eMERLIN_CASA_GUI.py
+++ b/functions/eMERLIN_CASA_GUI.py
@@ -35,6 +35,13 @@ class GUI_pipeline:
 		self.plots_dir_label.grid(row=6,column=3,columnspan=1,sticky='e')
 		self.plots_dir_entry = Entry(self.root,textvariable=self.plots_dir)
 		self.plots_dir_entry.grid(row=6,column=4,columnspan=3)
+		## Calibration directory ##
+		self.calib_dir = StringVar()
+		self.calib_dir.set('./calibration')
+		self.calib_dir_label = Label(self.root,text='Calibration directory:',justify='right')
+		self.calib_dir_label.grid(row=7,column=3,columnspan=1,sticky='e')
+		self.calib_dir_entry = Entry(self.root,textvariable=self.calib_dir)
+		self.calib_dir_entry.grid(row=7,column=4,columnspan=3)
 
 		##file names ###
 		self.inbase = StringVar()
@@ -176,6 +183,10 @@ class GUI_pipeline:
 		self.do_prediag_check = Checkbutton(self.root,text='Pre-diagnostics',variable =self.do_prediag,onvalue=1,offvalue=0,pady=5)
 		self.do_prediag_check.grid(row=16,column=0,sticky='w')
 
+		self.solve_delays = IntVar()
+		self.solve_delays_check = Checkbutton(self.root,text='Solve delays',variable =self.solve_delays,onvalue=1,offvalue=0,pady=5)
+		self.solve_delays_check.grid(row=17,column=0,sticky='w')
+
 		## Set parameters ##
 		self.w6 = Button(self.root,text='Confirm?',command=self.confirm_parameters)
 		self.w6.grid(row=100,column=2,sticky='e')
@@ -203,13 +214,14 @@ class GUI_pipeline:
 
 	def confirm_parameters(self):
 		self.inputs = {'quit':self.quit_var.get(),'data_dir':self.data_dir.get(),\
-		'plots_dir':self.plots_dir.get(),\
+		'plots_dir':self.plots_dir.get(),'calib_dir':self.calib_dir.get(),\
 		'inbase':self.inbase.get(),'targets':self.targets.get(),\
 		'phscals':self.phscals.get(),'fluxcal':self.fluxcal.get(),\
 		'bpcal':self.bpcal.get(),'ptcal':self.ptcal.get(),'refant':self.refant.get(),\
 		'run_importfits':self.run_importfits.get(),'hanning':self.hanning.get(),\
 		'autoflag':self.autoflag.get(),'rfigui':self.rfigui.get(),\
-		'ms2mms':self.ms2mms.get(),'do_prediag':self.do_prediag.get()}
+		'ms2mms':self.ms2mms.get(),'do_prediag':self.do_prediag.get(),\
+		'do_delay':self.solve_delays.get()}
 		return self.inputs
 
 	def printhistory(self):
@@ -263,13 +275,14 @@ class GUI_pipeline:
 
 	def check_inputs(self):
 		self.inputs = {'quit':self.quit_var.get(),'data_dir':self.data_dir.get(),\
-		'plots_dir':self.plots_dir.get(),\
+		'plots_dir':self.plots_dir.get(),'calib_dir':self.calib_dir.get(),\
 		'inbase':self.inbase.get(),'targets':self.targets.get(),\
 		'phscals':self.phscals.get(),'fluxcal':self.fluxcal.get(),\
 		'bpcal':self.bpcal.get(),'ptcal':self.ptcal.get(),'refant':self.refant.get(),\
 		'run_importfits':self.run_importfits.get(),'hanning':self.hanning.get(),\
 		'autoflag':self.autoflag.get(),'rfigui':self.rfigui.get(),\
-		'ms2mms':self.ms2mms.get(),'do_prediag':self.do_prediag.get()}
+		'ms2mms':self.ms2mms.get(),'do_prediag':self.do_prediag.get(),\
+		'do_delay':self.solve_delays.get()}
 		print self.inputs
 		input_key=self.inputs.keys()
 		input_values = self.inputs.values()

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -175,46 +175,49 @@ def run_rfigui(vis):
     os.system('rfigui '+vis)
     logger.info('End run_rfigui')
 
-#Run aoflagger. Mode = auto uses best fit strategy for e-MERLIN (credit J. Moldon), Mode=user uses custon straegy for each field
-def run_aoflagger(vis,mode):
-	if mode == 'user':
-		x = vishead(vis,mode='list',listitems='field')['field'][0]
-		os.system('touch pre-cal_flag_stats.txt')
-		y = []
-		for i in range(len(x)):
-			if os.path.isfile(x[i]+'.rfis')==False:
-				y=y+[x[i]]
-		if len(y) != 0:
-			for i in range(len(y)):
-				print 'Missing rfistrategy for: '+y[i]
-			print 'Please run step 3 again!'
-		else:
-			while True:
-				s = raw_input('All rfistrategys are there: Proceed?:\n')
-				if s == 'yes' or s == 'y':
-					ms.writehistory(message='eMER_CASA_Pipeline: AOFlag with user specified strategies:',msname=vis)
-					for i in range(len(x)):
-						ms.writehistory(message='eMER_CASA_Pipeline: Flagging field, '+x[i]+' with strategy: '+x[i]+'.rfis',msname=vis)
-						print 'Flagging field, '+x[i]+' with strategy: '+x[i]+'.rfis'
-						os.system('aoflagger -fields '+str(i)+' -strategy '+x[i]+'.rfis  '+vis+ '| tee -a pre-cal_flag_stats.txt')
-					break
-				if s == 'no' or s == 'n':
-					sys.exit('Please restart when you are happy')
-	elif mode == 'default':
-		print '---- Running AOflagger with eMERLIN default strategy ----\n'
-		os.system('aoflagger -strategy eMERLIN_default_ao_strategy_v1.rfis '+vis)
-		ms.writehistory(message='eMER_CASA_Pipeline: AOFlag with default strategy, complete',msname=vis)
-	else:
-		print 'Error: Please use either mode=user or mode=default'
-		sys.exit()
+##Run aoflagger. Mode = auto uses best fit strategy for e-MERLIN (credit J. Moldon), Mode=user uses custon straegy for each field
+#def run_aoflagger(vis,mode):
+#	if mode == 'user':
+#		x = vishead(vis,mode='list',listitems='field')['field'][0]
+#		os.system('touch pre-cal_flag_stats.txt')
+#		y = []
+#		for i in range(len(x)):
+#			if os.path.isfile(x[i]+'.rfis')==False:
+#				y=y+[x[i]]
+#		if len(y) != 0:
+#			for i in range(len(y)):
+#				print 'Missing rfistrategy for: '+y[i]
+#			print 'Please run step 3 again!'
+#		else:
+#			while True:
+#				s = raw_input('All rfistrategys are there: Proceed?:\n')
+#				if s == 'yes' or s == 'y':
+#					ms.writehistory(message='eMER_CASA_Pipeline: AOFlag with user specified strategies:',msname=vis)
+#					for i in range(len(x)):
+#						ms.writehistory(message='eMER_CASA_Pipeline: Flagging field, '+x[i]+' with strategy: '+x[i]+'.rfis',msname=vis)
+#						print 'Flagging field, '+x[i]+' with strategy: '+x[i]+'.rfis'
+#						os.system('aoflagger -fields '+str(i)+' -strategy '+x[i]+'.rfis  '+vis+ '| tee -a pre-cal_flag_stats.txt')
+#					break
+#				if s == 'no' or s == 'n':
+#					sys.exit('Please restart when you are happy')
+#	elif mode == 'default':
+#		print '---- Running AOflagger with eMERLIN default strategy ----\n'
+#		os.system('aoflagger -strategy eMERLIN_default_ao_strategy_v1.rfis '+vis)
+#		ms.writehistory(message='eMER_CASA_Pipeline: AOFlag with default strategy, complete',msname=vis)
+#	else:
+#		print 'Error: Please use either mode=user or mode=default'
+#		sys.exit()
 
 def run_aoflagger_fields(vis,fields='all', pipeline_path='./'):
     """This version of the autoflagger iterates through the ms within the mms structure selecting individual fields. It uses pre-defined strategies. The np.unique in the loop below is needed for single source files. The mms thinks there are many filds (one per mms). I think it is a bug from virtualconcat."""
     logger.info('Start run_aoflagger_fields')
+    vis_fields = vishead(vis,mode='list',listitems='field')['field'][0]
+    fields_num = {f:i for i,f in enumerate(vis_fields)}
     if fields == 'all':
-        fields = vishead(vis,mode='list',listitems='field')['field'][0]
+        fields = vis_fields
     else:
         fields = np.atleast_1d(fields)
+    old_aoflagger = check_aoflagger_version()
     for field in np.unique(fields):
         # First, check if user has a new strategy for this field in the local folder.
         # If not, check if user has produced a new strategy for this field in the pipeline folder (for typical sources, etc).
@@ -228,8 +231,11 @@ def run_aoflagger_fields(vis,fields='all', pipeline_path='./'):
             aostrategy = pipeline_path+'aoflagger_strategies/default/{0}.rfis'.format(field)
         else:
             aostrategy = pipeline_path+'aoflagger_strategies/default/{0}.rfis'.format('default_faint')
-        logger.info('Running AOFLagger for field {0} using strategy {1}'.format(field, aostrategy))
-        flagcommand = 'time aoflagger -strategy {0} {1}'.format(aostrategy, vis+'/SUBMSS/*{0}.mms.*.ms'.format(field))
+        logger.info('Running AOFLagger for field {0} ({1}) using strategy {2}'.format(field,fields_num[field], aostrategy))
+        if old_aoflagger: # < 2.9
+            flagcommand = 'time aoflagger -strategy {0} {1}'.format(aostrategy, vis+'/SUBMSS/*{0}.mms.*.ms'.format(field))
+        else: # >= 2.9
+            flagcommand = 'time aoflagger -fields {2} -strategy {0} {1}'.format(aostrategy, vis, fields_num[field])
         os.system(flagcommand+' | tee -a pre-cal_flag_stats.txt')
         ms.writehistory(message='eMER_CASA_Pipeline: AOFlag field {0} with strategy {1}:'.format(field, aostrategy),msname=vis)
     logger.info('End run_aoflagger_fields')
@@ -247,7 +253,6 @@ def check_aoflagger_version():
 	else:
 		old_aoflagger = False
 	logger.info('AOflagger version is {0}'.format(version))
-	old_aoflagger = True
 	return old_aoflagger
 
 def ms2mms(vis,mode):

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -5,7 +5,7 @@ from casa import ms
 import numpy as np
 from Tkinter import *
 import tkMessageBox
-import sys
+import sys, shutil
 import getopt
 #from task_importfitsidi import *
 from eMERLIN_CASA_GUI import GUI_pipeline
@@ -97,6 +97,29 @@ def check_history(vis):
 		for i in range(len(y)):
 			print x[y[i]]
 
+def makedir(pathdir):
+    try:
+        os.mkdir(pathdir)
+        logger.info('Create directory: {}'.format(pathdir))
+    except:
+        logger.debug('Cannot create directory: {}'.format(pathdir))
+        pass
+
+def rmdir(pathdir,message='Deleted:'):
+    try:
+        shutil.rmtree(pathdir)
+        logger.info('{0} {1}'.format(message, pathdir))
+    except:
+        logger.debug('Could not delete: {0} {1}'.format(message, pathdir))
+        pass
+
+def rmfile(pathdir,message='Deleted:'):
+    try:
+        os.remove(pathdir)
+        logger.info('{0} {1}'.format(message, pathdir))
+    except:
+        logger.debug('Could not delete: {0} {1}'.format(message, pathdir))
+        pass
 
 def run_importfitsIDI(data_dir,vis):
 	logger.info('Starting importfitsIDI procedure')

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -347,6 +347,21 @@ field=x[i], antenna='*&*', averagedata=True, avgtime=time, iteraxis='baseline', 
 	## Amplitude vs Time:
 	logger.info('End prediagnostics')
 
+def solve_delays(vis,caltable_name,calsources,solint,refant,caldir,plotdir,combine='',spw='',timerange='',minblperant=2,minsnr=2):
+    logger.info('Start solve_delays')
+    caltable = caldir+caltable_name
+    caltableplot = plotdir+caltable_name+'.png'
+    rmdir(caltable)
+    rmfile(caltableplot)
+    logger.info('Delay calibration in: {0}'.format(caltable))
+    logger.info('Delay calibration plot in: {0}'.format(caltableplot))
+    gaincal(vis=vis, gaintype='K', caltable=caltable, field=calsources, solint=solint, combine=combine, refant=refant, spw=spw, timerange=timerange, minblperant=minblperant, minsnr=minsnr)
+    logger.info('caltable: {0}, figfile: {1}'.format(caltable, caltableplot))
+    plotcal(caltable=caltable,xaxis='time',yaxis='delay',subplot=321,iteration='antenna',showgui=False,figfile=caltableplot, fontsize = 8)
+    logger.info('End solve_delays')
+    return
+
+
 def dfluxpy(freq,baseline):
 	#######
 	# Python version of 3C286 flux calculation program (original author unknown)

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -258,7 +258,7 @@ def check_aoflagger_version():
 def ms2mms(vis,mode):
 	logger.info('Start ms2mms')
 	if mode == 'parallel':
-		partition(vis=vis,outputvis=vis[:-3]+'.mms',createmms=True,separationaxis="auto",numsubms="auto",flagbackup=True,datacolumn=
+		partition(vis=vis,outputvis=vis[:-3]+'.mms',createmms=True,separationaxis="baseline",numsubms="auto",flagbackup=True,datacolumn=
 "all",field="",spw="",scan="",antenna="",correlation="",timerange="",intent="",array="",uvrange="",observation="",feed="",disableparallel=None,ddistart=None
 ,taql=None)
 		if os.path.isdir(vis[:-3]+'.mms') == True:

--- a/inputs.txt
+++ b/inputs.txt
@@ -2,6 +2,7 @@
 quit=0
 data_dir=./data/
 plots_dir=./plots/
+calib_dir=./calib/
 inbase=TEST1
 targets= '1241+602'
 phscals= '1236+612'
@@ -17,3 +18,4 @@ rfigui=0
 ms2mms=1
 autoflag=1
 do_prediag=0
+do_delay=1


### PR DESCRIPTION
- I have combined the two run_aoflagger functions into one. There are fundamentally the same, the only change is using -fields or using finding the /SUBMSS structure. Now the single function works for any aoflagger version.  Also, this simplifies the main script considerably.
- I have separated the ms2mms part from aoflagger part to simplify main script. There are still two ms2mms functions.
- I have added a delay calibration executed on all calibrators and a plot of the delay solutions that are plotted to a png image. @jradcliffe5 please add the parameter do_delay to the interactive input list.
- I already noticed some time ago that aoflagger was doing strange flagging on MMS when the separation axis was 'auto', and more reasonable results when separation axis is 'baseline'. I will open an issue so we can investigate this in more detail and with more data sets.
- For some reason I don't get exactly the same results on the flagging on ms2mms data and ms2mms_fields data. There are some small differences, but I don't see what could be the cause. As we discussed we should maintain only the direct ms2mms approach (with aoflagger 2.9), but in any case we need understand why this is happening.
