### PR TITLE
Bandpass

### DIFF
--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -17,7 +17,7 @@ import functions.eMERLIN_CASA_GUI as emGUI
 # Setup logger
 logger = logging.getLogger('logger')
 logger.setLevel(logging.INFO)
-handler = logging.FileHandler('eMCP.log') # create a file handler
+handler = logging.FileHandler('eMCP.log', mode = 'a') # create a file handler
 handler.setLevel(logging.INFO)
 formatter = logging.Formatter(fmt='%(asctime)s.%(msecs)1d | %(levelname)s | %(message)s',datefmt='%Y-%m-%d %H:%M:%S')
 handler.setFormatter(formatter)
@@ -37,6 +37,8 @@ calib_dir = em.backslash_check(inputs['calib_dir'])
 logger.info('Inputs used: {}'.format(inputs))
 
 refant = inputs['refant']
+bpcal = '1407+284'	# We need a function to check if it is present in the MS
+
 
 ## Create directory structure ##
 em.makedir(plots_dir)
@@ -92,8 +94,14 @@ if inputs['do_prediag'] == 1:
 
 ### Delay calibration ###
 if inputs['do_delay'] == 1:
-    caltable_name = inputs['inbase']+'_delay.K'
-    em.solve_delays(vis,caltable_name=caltable_name,calsources='',solint='600s',refant=refant,combine='spw',spw='',caldir=calib_dir,plotdir=plots_dir)
+    delay_caltable = inputs['inbase']+'_delay.K'
+    em.solve_delays(vis,caltable_name=delay_caltable,calsources='',solint='600s',refant=refant,combine='spw',spw='',caldir=calib_dir,plotdir=plots_dir)
+
+### Initial BandPass calibration ###
+if inputs['do_initial_bandpass'] == 1:
+    if os.path.isdir(calib_dir+inputs['inbase']+'_delay.K'):
+        previous_caltable = calib_dir+inputs['inbase']+'_delay.K'
+    em.initial_bp_cal(vis, bpcal, refant, caldir=calib_dir,plotdir=plots_dir,previous_cal=previous_caltable, solint='30s')
 
 
 

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -404,7 +404,7 @@ def initial_bp_cal(msfile, bpcal, refant, caldir, plotdir,previous_cal='', solin
     logger.info('Previous calibration applied: {0}'.format(', '.join(previous_cal)))
     logger.info('Previous calibration spwmap: {0}'.format(str([spwmap0,spwmap1])))
     logger.info('Generating calibration table: {0}'.format(caltable2))
-    gaincal(vis=msfile,calmode=calmode1,field=bpcal,caltable=caltable2,solint=solint2,refant=refant,gaintable=previous_cal,minblperant=minblperant,minsnr=minsnr, spwmap = [spwmap0, spwmap1])
+    gaincal(vis=msfile,calmode=calmode2,field=bpcal,caltable=caltable2,solint=solint2,refant=refant,gaintable=previous_cal,minblperant=minblperant,minsnr=minsnr, spwmap = [spwmap0, spwmap1])
     logger.info('caltable: {0}, figfile: {1}'.format(caltable2, caltableplot2))
     plotcal(caltable=caltable2,xaxis='time',yaxis='amp',subplot=321,iteration='antenna',showgui=False,figfile=caltableplot2, fontsize = 8, plotrange = [-1,-1,-1,-1])
     logger.info('End initial_bp_cal')

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -361,6 +361,61 @@ def solve_delays(vis,caltable_name,calsources,solint,refant,caldir,plotdir,combi
     logger.info('End solve_delays')
     return
 
+def initial_bp_cal(msfile, bpcal, refant, caldir, plotdir,previous_cal='', solint='30s', minblperant=2, minsnr=2):
+    # This should be implemented in the main script
+    num_spw = len(vishead(msfile, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
+    logger.info('Start initial_bp_cal')
+    if previous_cal == '':
+        logger.info('No previous calibration being applied now')
+        previous_cal = []
+    else:
+        previous_cal = previous_cal.split() # To convert to list. Maybe we should force it to be a list
+
+    spwmap0 = [0]*num_spw
+    # We need a consistent way to pass previous calibration tables and spwmap from one task to another
+    # We should create a mycal.txt file with the list of calibrations to apply them in plotms on the fly
+
+    # 1 Phase calibration
+    calmode1 = 'p'
+    solint1 = '10s'
+    caltable1 = caldir+'bpcal.'+bpcal+'_precal.G1'
+    spwmap1 = range(num_spw)
+    caltableplot1 = plotdir+'bpcal.'+bpcal+'_precal.G1'+'.png'
+    rmdir(caltable1)
+    rmfile(caltableplot1)
+    logger.info('Running gaincal on field {0}, calmode = {1}, solint = {2}'.format(bpcal, calmode1, solint1))
+    logger.info('Previous calibration applied: {0}'.format(', '.join(previous_cal)))
+    logger.info('Previous calibration spwmap: {0}'.format(str(spwmap0)))
+    logger.info('Generating calibration table: {0}'.format(caltable1))
+    gaincal(vis=msfile,calmode=calmode1,field=bpcal,caltable=caltable1,solint=solint1,refant=refant,gaintable=previous_cal,minblperant=minblperant,minsnr=minsnr, spwmap = spwmap0)
+    logger.info('caltable: {0}, figfile: {1}'.format(caltable1, caltableplot1))
+    plotcal(caltable=caltable1,xaxis='time',yaxis='phase',subplot=321,iteration='antenna',showgui=False,figfile=caltableplot1, fontsize = 8, plotrange = [-1,-1,-180,180])
+
+    # 2 A&P calibration
+    previous_cal.append(caltable1)
+    calmode2 = 'ap'
+    solint2 = '120s'
+    caltable2 = caldir+'bpcal.'+bpcal+'_precal.G2'
+    spwmap2 = range(num_spw)
+    caltableplot2 = plotdir+'bpcal.'+bpcal+'_precal.G2'+'.png'
+    rmdir(caltable2)
+    rmfile(caltableplot2)
+    logger.info('Running gaincal on field {0}, calmode = {1}, solint = {2}'.format(bpcal, calmode2, solint2))
+    logger.info('Previous calibration applied: {0}'.format(', '.join(previous_cal)))
+    logger.info('Previous calibration spwmap: {0}'.format(str([spwmap0,spwmap1])))
+    logger.info('Generating calibration table: {0}'.format(caltable2))
+    gaincal(vis=msfile,calmode=calmode1,field=bpcal,caltable=caltable2,solint=solint2,refant=refant,gaintable=previous_cal,minblperant=minblperant,minsnr=minsnr, spwmap = [spwmap0, spwmap1])
+    logger.info('caltable: {0}, figfile: {1}'.format(caltable2, caltableplot2))
+    plotcal(caltable=caltable2,xaxis='time',yaxis='amp',subplot=321,iteration='antenna',showgui=False,figfile=caltableplot2, fontsize = 8, plotrange = [-1,-1,-1,-1])
+    logger.info('End initial_bp_cal')
+
+    # 3 Bandpass calibration
+
+
+    return
+
+
+
 
 def dfluxpy(freq,baseline):
 	#######

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -390,9 +390,9 @@ def initial_bp_cal(msfile, bpcal, refant, caldir, plotdir,previous_cal='', solin
     gaincal(vis=msfile,calmode=calmode1,field=bpcal,caltable=caltable1,solint=solint1,refant=refant,gaintable=previous_cal,minblperant=minblperant,minsnr=minsnr, spwmap = spwmap0)
     logger.info('caltable: {0}, figfile: {1}'.format(caltable1, caltableplot1))
     plotcal(caltable=caltable1,xaxis='time',yaxis='phase',subplot=321,iteration='antenna',showgui=False,figfile=caltableplot1, fontsize = 8, plotrange = [-1,-1,-180,180])
+    previous_cal.append(caltable1)
 
     # 2 A&P calibration
-    previous_cal.append(caltable1)
     calmode2 = 'ap'
     solint2 = '120s'
     caltable2 = caldir+'bpcal.'+bpcal+'_precal.G2'
@@ -407,11 +407,24 @@ def initial_bp_cal(msfile, bpcal, refant, caldir, plotdir,previous_cal='', solin
     gaincal(vis=msfile,calmode=calmode2,field=bpcal,caltable=caltable2,solint=solint2,refant=refant,gaintable=previous_cal,minblperant=minblperant,minsnr=minsnr, spwmap = [spwmap0, spwmap1])
     logger.info('caltable: {0}, figfile: {1}'.format(caltable2, caltableplot2))
     plotcal(caltable=caltable2,xaxis='time',yaxis='amp',subplot=321,iteration='antenna',showgui=False,figfile=caltableplot2, fontsize = 8, plotrange = [-1,-1,-1,-1])
-    logger.info('End initial_bp_cal')
+    previous_cal.append(caltable2)
 
     # 3 Bandpass calibration
-
-
+    bptable0 = caldir+'bpcal.'+bpcal+'_precal.B0'
+    bptableplot0_phs = plotdir+'bpcal.'+bpcal+'_precal.B0_phs'+'.png'
+    bptableplot0_amp = plotdir+'bpcal.'+bpcal+'_precal.B0.amp'+'.png'
+    rmdir(bptable0)
+    rmfile(bptableplot0_phs)
+    rmfile(bptableplot0_amp)
+    logger.info('Running bandpass on field {0}, solint = {1}, combine = {2}'.format(bpcal, 'inf', 'scan'))
+    logger.info('Previous calibration applied: {0}'.format(', '.join(previous_cal)))
+    logger.info('Previous calibration spwmap: {0}'.format(str([spwmap0,spwmap1,spwmap2])))
+    logger.info('Generating bandpass table: {0}'.format(bptable0))
+    bandpass(vis=msfile, caltable=bptable0, field=bpcal, fillgaps=16, solint='inf', combine='scan', solnorm=True, refant=refant, minblperant=2, gaintable=previous_cal, spwmap=[spwmap0, spwmap1, spwmap2], minsnr=3)
+    logger.info('bptable: {0}, figfile: {1}'.format(bptable0, ', '.join([bptableplot0_phs, bptableplot0_amp])))
+    plotcal(caltable=bptable0,xaxis='freq',yaxis='phase',subplot=321,iteration='antenna',showgui=False,figfile=bptableplot0_phs, fontsize = 8, plotrange = [-1,-1,-180,180])
+    plotcal(caltable=bptable0,xaxis='freq',yaxis='amp',  subplot=321,iteration='antenna',showgui=False,figfile=bptableplot0_amp, fontsize = 8, plotrange = [-1,-1,-1,-1])
+    logger.info('End initial_bp_cal')
     return
 
 

--- a/inputs.txt
+++ b/inputs.txt
@@ -19,3 +19,4 @@ ms2mms=1
 autoflag=1
 do_prediag=0
 do_delay=1
+do_initial_bandpass=1


### PR DESCRIPTION
Ready and working. function em.initial_bp_cal runs on 1407+284 a 'p', 'ap' calibrations and then runs bandpass. It produces plots of all the calibration tables produced.

We may want to define sub functions to tasks that are repeated because the function is a bit long. We also need to think about a clear way to pass calibration tables from one task to the next, even when not all tasks are executed.

Bandpass table on one baseline:
![bandpass](https://cloud.githubusercontent.com/assets/1053066/25016180/dd88286a-2076-11e7-93bf-1021fd244c18.png)

Amplitude pre calibration
![amp_pre_calibration](https://cloud.githubusercontent.com/assets/1053066/25016194/e7151942-2076-11e7-903c-96d45a87f755.png)

Amplitude post calibration
![amp_post_calibration](https://cloud.githubusercontent.com/assets/1053066/25016205/ef2c3c46-2076-11e7-9ab6-6967688d7283.png)

Phase pre calibration
![phs_pre_calibration](https://cloud.githubusercontent.com/assets/1053066/25016213/f6d12fc4-2076-11e7-8fdb-b94b198254f3.png)

Phase post calibration
![phs_post_calibration1](https://cloud.githubusercontent.com/assets/1053066/25016220/015420be-2077-11e7-8856-b5ddda5e7d07.png)
