### PR TITLE
Smooth bp

### DIFF
--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -7,6 +7,7 @@ from casa import ms
 from Tkinter import *
 import getopt
 import logging
+import pickle
 
 # Find path of pipeline to find external files (like aoflagger strategies or emerlin-2.gif)
 pipeline_path = os.path.dirname(sys.argv[np.where(np.asarray(sys.argv)=='-c')[0][0] + 1]) + '/'
@@ -93,21 +94,20 @@ if inputs['autoflag'] == 1:
 if inputs['do_prediag'] == 1:
 	em.do_prediagnostics(vis,plots_dir)
 
-previous_cal = []
-previous_spwmap = []
+try:
+    caltables = pickle.load('caltables.dic')
+except:
+    caltables = {}
 
 ### Delay calibration ###
 if inputs['do_delay'] == 1:
-    caltables['delay0'] = em.solve_delays(vis, calsources='', solint='600s', refant=refant, combine='spw', spw='', caldir=calib_dir, plotdir=plots_dir)
-
-#if os.path.isdir(calib_dir+inputs['inbase']+'_delay.K'):
-#    num_spw = len(vishead(vis, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
-#    previous_cal.append(calib_dir+inputs['inbase']+'_delay.K')
-#    previous_spwmap.append([0]*num_spw)
+    caltables = em.solve_delays(msfile=vis, inbase=inputs['inbase'], calsources='', solint='600s', refant=refant, combine='spw', spw='', caldir=calib_dir, plotdir=plots_dir, caltables=caltables)
+    pickle.dump(caltables, open('caltables.dic', 'wb'))
 
 ### Initial BandPass calibration ###
 if inputs['do_initial_bandpass'] == 1:
-    caltables['bpcal0'] = em.initial_bp_cal(msfile=vis, bpcal=bpcal, refant=refant, caldir=calib_dir, plotdir=plots_dir, previous_cal=caltables)
+    caltables = em.initial_bp_cal(msfile=vis, inbase=inputs['inbase'], bpcal=bpcal, refant=refant, caldir=calib_dir, plotdir=plots_dir, caltables=caltables)
+    pickle.dump(caltables, open('caltables.dic', 'wb'))
 
 
 logger.info('Pipeline finished')

--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -98,17 +98,16 @@ previous_spwmap = []
 
 ### Delay calibration ###
 if inputs['do_delay'] == 1:
-    delay_caltable = inputs['inbase']+'_delay.K'
-    caltable_delay, spwmap_out_delay = em.solve_delays(vis,caltable_name=delay_caltable,calsources='',solint='600s',refant=refant,combine='spw',spw='',caldir=calib_dir,plotdir=plots_dir)
+    caltables['delay0'] = em.solve_delays(vis, calsources='', solint='600s', refant=refant, combine='spw', spw='', caldir=calib_dir, plotdir=plots_dir)
 
-if os.path.isdir(calib_dir+inputs['inbase']+'_delay.K'):
-    num_spw = len(vishead(vis, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
-    previous_cal.append(calib_dir+inputs['inbase']+'_delay.K')
-    previous_spwmap.append([0]*num_spw)
+#if os.path.isdir(calib_dir+inputs['inbase']+'_delay.K'):
+#    num_spw = len(vishead(vis, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
+#    previous_cal.append(calib_dir+inputs['inbase']+'_delay.K')
+#    previous_spwmap.append([0]*num_spw)
 
 ### Initial BandPass calibration ###
 if inputs['do_initial_bandpass'] == 1:
-    em.initial_bp_cal(msfile=vis, bpcal=bpcal, refant=refant, caldir=calib_dir, plotdir=plots_dir, previous_cal=previous_cal,  previous_spwmap=previous_spwmap)
+    caltables['bpcal0'] = em.initial_bp_cal(msfile=vis, bpcal=bpcal, refant=refant, caldir=calib_dir, plotdir=plots_dir, previous_cal=caltables)
 
 
 logger.info('Pipeline finished')

--- a/functions/eMERLIN_CASA_functions.py
+++ b/functions/eMERLIN_CASA_functions.py
@@ -380,21 +380,120 @@ field=x[i], antenna='*&*', averagedata=True, avgtime=time, iteraxis='baseline', 
 	## Amplitude vs Time:
 	logger.info('End prediagnostics')
 
-def solve_delays(vis,caltable_name,calsources,solint,refant,caldir,plotdir,combine='',spw='',timerange='',minblperant=2,minsnr=2):
+def solve_delays(msfile, caltable_name, calsources, solint, refant, caldir, plotdir, combine='', spw='', timerange='', minblperant=2, minsnr=2):
     logger.info('Start solve_delays')
+    # This should be implemented in the main script
+    num_spw = len(vishead(msfile, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
+    spwmap_out = [0]*num_spw
     caltable = caldir+caltable_name
     caltableplot = plotdir+caltable_name+'.png'
     rmdir(caltable)
     rmfile(caltableplot)
     logger.info('Delay calibration in: {0}'.format(caltable))
     logger.info('Delay calibration plot in: {0}'.format(caltableplot))
-    gaincal(vis=vis, gaintype='K', caltable=caltable, field=calsources, solint=solint, combine=combine, refant=refant, spw=spw, timerange=timerange, minblperant=minblperant, minsnr=minsnr)
+    gaincal(vis=msfile, gaintype='K', caltable=caltable, field=calsources, solint=solint, combine=combine, refant=refant, spw=spw, timerange=timerange, minblperant=minblperant, minsnr=minsnr)
     logger.info('caltable: {0}, figfile: {1}'.format(caltable, caltableplot))
     plotcal(caltable=caltable,xaxis='time',yaxis='delay',subplot=321,iteration='antenna',showgui=False,figfile=caltableplot, fontsize = 8)
     logger.info('End solve_delays')
+    return caltable, spwmap_out
+
+
+def run_gaincal(msfile, caltable, calmode, solint, field, combine, refant, spw, previous_cal, previous_spwmap, caldir, plotdir, subplot, iteration, plotrange_phs = [-1,-1,-180,180], plotrange_amp = [-1,-1,-1,-1], timerange='', minblperant=2, minsnr=2):
+    # This should be implemented in the main script
+    num_spw = len(vishead(msfile, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
+    if 'spw' in combine.split():
+        spwmap_out = [0]*num_spw
+    else:
+        spwmap_out = range(num_spw)
+    basename = os.path.basename(caltable)
+    caltableplot_phs = plotdir + basename +'_phs.png'
+    caltableplot_amp = plotdir + basename +'_amp.png' 
+    rmdir(caltable)
+    rmfile(caltableplot_phs)
+    rmfile(caltableplot_amp)
+    logger.info('Running gaincal on field {0}, calmode = {1}, solint = {2}'.format(field, calmode, solint))
+    logger.info('Previous calibration applied: {0}'.format(', '.join(previous_cal)))
+    logger.info('Previous calibration spwmap: {0}'.format(previous_spwmap))
+    logger.info('Generating calibration table: {0}'.format(caltable))
+    gaincal(vis=msfile, calmode=calmode, field=field, caltable=caltable, solint=solint, combine=combine, refant=refant, spw=spw, timerange=timerange, gaintable=previous_cal, spwmap = previous_spwmap, minblperant=minblperant, minsnr=minsnr)
+    logger.info('caltable: {0}, figfiles: {1}, {2}'.format(caltable, caltableplot_phs, caltableplot_amp))
+    plotcal(caltable=caltable, xaxis='time', yaxis='phase', subplot=subplot, iteration=iteration, showgui=False, figfile=caltableplot_phs, fontsize = 8, plotrange = plotrange_phs)
+    plotcal(caltable=caltable, xaxis='time', yaxis='amp', subplot=subplot, iteration=iteration, showgui=False, figfile=caltableplot_amp, fontsize = 8, plotrange = plotrange_amp)
+    return caltable, spwmap_out
+
+def run_bandpass(msfile, bptable, bpcal, refant, previous_cal, previous_spwmap, caldir, plotdir, spw='', solint='inf', combine='scan'):
+    # This should be implemented in the main script
+    num_spw = len(vishead(msfile, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
+    if 'spw' in combine.split():
+        spwmap_out = [0]*num_spw
+    else:
+        spwmap_out = range(num_spw)
+    basename = os.path.basename(bptable)
+    bptableplot_phs = plotdir+basename+'_phs'+'.png'
+    bptableplot_amp = plotdir+basename+'_amp'+'.png'
+    rmdir(bptable)
+    rmfile(bptableplot_phs)
+    rmfile(bptableplot_amp)
+    logger.info('Running bandpass on field {0}, solint = {1}, combine = {2}'.format(bpcal, solint, combine))
+    logger.info('Previous calibration applied: {0}'.format(', '.join(previous_cal)))
+    logger.info('Previous calibration spwmap: {0}'.format(previous_spwmap))
+    logger.info('Generating bandpass table: {0}'.format(bptable))
+    bandpass(vis=msfile, caltable=bptable, field=bpcal, fillgaps=16, solint=solint, combine=combine, solnorm=True, refant=refant, minblperant=2, gaintable=previous_cal, spwmap = previous_spwmap, minsnr=3)
+    logger.info('bptable: {0}, figfile: {1}'.format(bptable, ', '.join([bptableplot_phs, bptableplot_amp])))
+    plotcal(caltable=bptable, xaxis='freq', yaxis='phase', subplot=321,iteration='antenna', showgui=False, figfile=bptableplot_phs, fontsize = 8, plotrange = [-1,-1,-180,180])
+    plotcal(caltable=bptable, xaxis='freq', yaxis='amp',  subplot=321, iteration='antenna', showgui=False, figfile=bptableplot_amp, fontsize = 8, plotrange = [-1,-1,-1,-1])
+    logger.info('End initial_bp_cal')
+    return bptable, spwmap_out
+
+def smooth_caltable(msfile, tablein, plotdir, caltable='', field='', smoothtype='median', smoothtime=120.):
+    logger.info('Smoothing table: {0}, field {1}, smoothtype {2}, smoothtime {3}'.format(tablein, field, smoothtype, smoothtime))
+    basename = os.path.basename(tablein)
+    caltableplot_phs = plotdir + basename +'_phs.png'
+    caltableplot_amp = plotdir + basename +'_amp.png'
+    if caltable=='':
+        os.system('mv {0} {1}'.format(caltableplot_phs, plotdir + basename +'_phs_pre_smooth.png'))
+        os.system('mv {0} {1}'.format(caltableplot_amp, plotdir + basename +'_amp_pre_smooth.png'))
+    smoothcal(vis=msfile, tablein=tablein, caltable=tablein+'smooth', field='', smoothtype='median', smoothtime=60*20.)
+    logger.info('Pre-smoothing table saved to: {0}'.format(tablein+'_pre_smooth'))
+    os.system('mv {0} {1}'.format(tablein, tablein+'_pre_smooth'))
+    os.system('mv {0} {1}'.format(tablein+'smooth', tablein))
+    plotcal(caltable=tablein, xaxis='time', yaxis='phase', subplot=321, iteration='antenna', showgui=False, figfile=caltableplot_phs, fontsize = 8, plotrange=[-1,-1,-180,180])
+    plotcal(caltable=tablein, xaxis='time', yaxis='amp', subplot=321, iteration='antenna', showgui=False, figfile=caltableplot_amp, fontsize = 8, plotrange=[-1,-1,-1,-1])
     return
 
-def initial_bp_cal(msfile, bpcal, refant, caldir, plotdir,previous_cal='', solint='30s', minblperant=2, minsnr=2):
+def initial_bp_cal(msfile, bpcal, refant, caldir, plotdir, previous_cal=[], previous_spwmap=[], minblperant=2, minsnr=2):
+    logger.info('Start initial_bp_cal')
+    # This should be implemented in the main script
+    num_spw = len(vishead(msfile, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
+
+    # 1 Phase calibration
+    calmode1 = 'p'
+    solint1 = '10s'
+    caltable1 = caldir+inputs['inbase']+'_bpcal0.G0'
+    spwmap1 = range(num_spw)
+    run_gaincal(msfile=msfile, caltable=caltable1, calmode=calmode1, solint=solint1, field=bpcal, combine='', refant=refant, spw='', previous_cal=previous_cal, previous_spwmap=previous_spwmap, caldir=caldir, plotdir=plotdir, subplot=321, iteration='antenna', plotrange_phs = [-1,-1,-180,180])
+    previous_cal.append(caltable1)
+    previous_spwmap.append(spwmap1)
+
+    # 2 A&P calibration
+    calmode2 = 'ap'
+    solint2 = '120s'
+    caltable2 = caldir+'bpcal.'+bpcal+'_bpcal0.G1'
+    spwmap2 = range(num_spw)
+    run_gaincal(msfile=msfile, caltable=caltable2, calmode=calmode2, solint=solint2, field=bpcal, combine='', refant=refant, spw='', previous_cal=previous_cal, previous_spwmap=previous_spwmap, caldir=caldir, plotdir=plotdir, subplot=321, iteration='antenna', plotrange_phs = [-1,-1,-180,180])
+    smooth_caltable(msfile=msfile, plotdir=plotdir, tablein=caltable2, caltable='', field='', smoothtype='median', smoothtime=60*20.)
+    previous_cal.append(caltable2)
+    previous_spwmap.append(spwmap2)
+
+    # 3 Bandpass calibration
+    bptable0 = caldir+'bpcal.'+bpcal+'_bpcal0.B0'
+    bptableplot0_phs = plotdir+'bpcal.'+bpcal+'_precal.B0_phs'+'.png'
+    bptableplot0_amp = plotdir+'bpcal.'+bpcal+'_precal.B0.amp'+'.png'
+    run_bandpass(msfile=msfile, bptable=bptable0, bpcal=bpcal, refant=refant, previous_cal=previous_cal, previous_spwmap=previous_spwmap, caldir=caldir, plotdir=plotdir, spw='', solint='inf', combine='scan')
+    return
+
+
+def initial_bp_cal_old(msfile, bpcal, refant, caldir, plotdir,previous_cal='', solint='30s', minblperant=2, minsnr=2):
     # This should be implemented in the main script
     num_spw = len(vishead(msfile, mode = 'list', listitems = ['spw_name'])['spw_name'][0])
     logger.info('Start initial_bp_cal')


### PR DESCRIPTION
New version with Initial bandpass completed.

- I have rewritten all the previous calibration used/produced by `solve_delays` and `do_initial_bandpass`.
- Now a single dictionary keeps all the information following the table structure described in #39.
- Right now it assumes the pipeline has been run up to the requested step (so the dictionary contains what the previous steps produced and the tables are available in the calib directory). We can add additional checks to verify that they are there, and if not give an error.
- I have rewritten new smaller and general functions: `run_gaincal`, `run_bandpass` that can be called later with other parameters.
- I have included a `smooth_caltable` function. Now it is executed only on the initial_bandpass "ap" calibration step. I keep a backup table before the smoothing.
- Now I produce plots for all calibration tables. When gaintype is 'G' I always produce amplitude and phase only (also even if we don't solve for amplitudes), to have all the information of what is being applied.

