### PR TITLE
Refant

### DIFF
--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -15,6 +15,8 @@ sys.path.append(pipeline_path)
 import functions.eMERLIN_CASA_functions as em
 import functions.eMERLIN_CASA_GUI as emGUI
 
+casalog.setlogfile('casa_eMCP.log')
+
 # Setup logger
 logger = logging.getLogger('logger')
 logger.setLevel(logging.INFO)
@@ -164,16 +166,16 @@ else:
 logger.info('Using MS file: {0}'.format(msfile))
 
 
-
 ### Load manual flagging file
 if inputs['flag_2b_manual'] == 1:
     flags = em.flagdata2_manual(msfile=msfile, inpfile=inputs['manual_flags_b'], flags=flags)
 
+
+### Retrieve MS information
 # Sources in the MS
 sources['msfile_fields'] = ','.join(vishead(msfile,mode='list',listitems='field')['field'][0])
 logger.info('Sources in MS {0}: {1}'.format(msfile, sources['msfile_fields']))
 
-### Retrieve MS information
 # Antenna list and reference antenna
 ms.open(msfile)
 d = ms.getdata(['axis_info'],ifraxis=True)
@@ -189,8 +191,7 @@ refant_in_ms = (np.array([ri in antennas for ri in refant_user])).all()
 
 if not refant_in_ms:
     if refant != '':
-        logger.warning('Selected reference antenna(s) {0} not in MS! User\
-                       selection will be ignored'.format(refant))
+        logger.warning('Selected reference antenna(s) {0} not in MS! User selection will be ignored'.format(refant))
     # Finding best antennas for refant
     refant, refant_pref = em.find_refant(msfile, field=sources['bpcal'],
                                          antennas='Mk2,Pi,Da,Kn', spws='2,3', scan='')


### PR DESCRIPTION
I included a function to automatically search for best set of antennas to be used as reference antennas: em.find_refant

The idea is the following:
- The task uses visstat() to get statistics on the amplitudes of different baselines, spw, field, correlation.
- It will iterate through all parameters and create a matrix of S/N, averaging all baselines to each station.
- Then it will average the S/N for all correlations and spw considered.
- It then ranks the antennas in decreasing average S/N value.

The pipeline will use the inputs['refant'] parameter. If all the selected antenna(s) are not in the MS, it will start a search automatically, and use the result for the rest of the calibration. It also accepts an empty string. Searching all antennas using statistics on all spw takes a lot of time. To be faster, by default the pipeline searches:
- Only the best of Mk2,Pi,Da,Kn
- Only spw 2, 3
- Only central half of the channels (128~384 when nchan=512, and proportional otherwise).
- Only the bandpass calibrator
- It will use amplitudes on the DATA column

Also, I have fixed some bugs on how the inputs parameters are read when a comma-separated list is provided.

I have also grouped several steps checking the content of the MS (antennas, fields, etc) and put them after checking if there is an _avg data set. That makes sures everything works in case the user is working with the _avg data set and has removed the original data set.

The pipeline now stores the casa log in casa_eMCP.log. It is not removed when re-runing the pipeline, so every step ever conducted will be there, unless the user deletes the file.
