### PR TITLE
Updated detection of pipeline path to work with CASA 5.1.1

### DIFF
--- a/eMERLIN_CASA_pipeline.py
+++ b/eMERLIN_CASA_pipeline.py
@@ -13,10 +13,8 @@ from tasks import *
 pipeline_version = 'v0.7.2'
 
 # Find path of pipeline to find external files (like aoflagger strategies or emerlin-2.gif)
-try:
-    pipeline_path = os.path.dirname(sys.argv[np.where(np.asarray(sys.argv)=='-c')[0][0] + 1]) + '/'
-except:
-    pass
+pipeline_filename = sys.argv[sys.argv.index('-c') + 1]
+pipeline_path = os.path.abspath(os.path.dirname(pipeline_filename))
 
 sys.path.append(pipeline_path)
 import functions.eMERLIN_CASA_functions as em


### PR DESCRIPTION
If the pipeline is run from the same directory as the data, CASA 5.1.1 would crash as the previous lines would add '/' to the path instead of the current directory. The os.path.abspath in the second line prevents this from happening. Note: the current directory was in the CASA path by default for CASA 5.0.0 so the pipeline did not crash for this version.

The first line which sets pipeline_filename is now updated to not require numpy.